### PR TITLE
edits to get_highest_snpeff_effect

### DIFF
--- a/scgenome/loaders/snv.py
+++ b/scgenome/loaders/snv.py
@@ -43,7 +43,7 @@ def load_snv_count_data(pseudobulk_dir, positions):
         csv_input = scgenome.csvutils.CsvInput(filepath)
         data = csv_input.read_csv(
             dtypes_override={
-                'chrom': 'category',
+                'chrom': 'str',
                 'ref': 'category',
                 'alt': 'category',
                 'cell_id': 'category',
@@ -85,7 +85,7 @@ def load_snv_annotation_table(pseudobulk_dir, table_name):
         csv_input = scgenome.csvutils.CsvInput(filepath)
         data = csv_input.read_csv(
             dtypes_override={
-                'chrom': 'category',
+                'chrom': 'str',
                 'ref': 'category',
                 'alt': 'category',
                 'cell_id': 'category',
@@ -188,8 +188,6 @@ def load_snv_annotation_results(pseudobulk_dir, museq_filter=None, strelka_filte
     cosmic = cosmic[['chrom', 'coord', 'ref', 'alt', 'is_cosmic']].drop_duplicates()
 
     snpeff = load_snv_annotation_table(pseudobulk_dir, 'snpeff')
-    snpeff["chrom"] = list(map(str, snpeff["chrom"]))
-    snpeff["chrom"] = snpeff["chrom"].astype("category")
     snpeff = get_highest_snpeff_effect(snpeff, override_coding=override_coding)
     logging.info(f'snpeff table with shape {snpeff.shape}, memory {snpeff.memory_usage().sum()}')
     logging.info(f'snpeff: number of unique mutations: {snpeff[["chrom", "ref", "alt", "coord"]].drop_duplicates().shape[0]}')

--- a/scgenome/loaders/snv.py
+++ b/scgenome/loaders/snv.py
@@ -181,13 +181,17 @@ def load_snv_annotation_results(pseudobulk_dir, museq_filter=None, strelka_filte
     cosmic = cosmic[['chrom', 'coord', 'ref', 'alt', 'is_cosmic']].drop_duplicates()
 
     snpeff = load_snv_annotation_table(pseudobulk_dir, 'snpeff')
+    snpeff["chrom"] = list(map(str, snpeff["chrom"]))
+    snpeff["chrom"] = snpeff["chrom"].astype("category")
     snpeff = get_highest_snpeff_effect(snpeff)
     logging.info(f'snpeff table with shape {snpeff.shape}, memory {snpeff.memory_usage().sum()}')
+    logging.info(f'snpeff: number of unique mutations: {snpeff[["chrom", "ref", "alt", "coord"]].drop_duplicates().shape[0]}')
 
     tnc = load_snv_annotation_table(pseudobulk_dir, 'trinuc')
 
     data = load_snv_annotation_table(pseudobulk_dir, 'allele_counts')
     logging.info(f'initial snv table with shape {data.shape}, memory {data.memory_usage().sum()}')
+    logging.info(f'initial snv table, number of unique mutations: {data[["chrom", "ref", "alt", "coord"]].drop_duplicates().shape[0]}')
 
     logging.info('summing snv counts')
     data = (
@@ -205,7 +209,7 @@ def load_snv_annotation_results(pseudobulk_dir, museq_filter=None, strelka_filte
     logging.info('post cosmic with snv count {}'.format(data[['chrom', 'coord']].drop_duplicates().shape[0]))
     logging.info(f'snv table with shape {data.shape}, memory {data.memory_usage().sum()}')
 
-    data = data.merge(snpeff, how='left')
+    data = data.merge(snpeff, how='left', on=['chrom', 'coord', 'ref', 'alt'])
     logging.info('post snpeff with snv count {}'.format(data[['chrom', 'coord']].drop_duplicates().shape[0]))
     logging.info(f'snv table with shape {data.shape}, memory {data.memory_usage().sum()}')
 
@@ -235,6 +239,7 @@ def load_snv_annotation_results(pseudobulk_dir, museq_filter=None, strelka_filte
 
     for column in categorical_columns:
         data[column] = data[column].astype('category')
+
 
     logging.info(f'final snv table with shape {data.shape}, memory {data.memory_usage().sum()}')
 


### PR DESCRIPTION
This does 2 things:

1) Commit aed97ff is a bit of a hack that fixes a bug with merging the snv table and the snpeff table that I encountered. I found that the categories in the snpeff table were sometimes a mix of integers and strings causing issues when merging. I don't know if it's general but it happens to me with ticket SC-2655. This needs fixing properly but I can't really work out why it's happening.

This will reproduce the problem:
```
x = load_snv_annotation_table("/path/to/ticket/SC-2655/variants", "snpeff")
pandas.unique(x.chrom).categories
```

```
Index([  1,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,   2,  20,  21,
        22,   3,   4,   5,   6,   7,   8,   9, '9', 'X', 'Y', '8'],
      dtype='object')
```

2) Commit e669b41 adds an option to override the highest impact snpeff annotation even if there is a non-synonymous mutation that has lower "impact". For example again in SC-2655 there is a TP53 mutation where the highest impact annotation is a protein interaction locus, but it is also a non-synoymous mutation. Most of the time I think it's more useful to have the latter information. 